### PR TITLE
fix: upload GitHub Pages artifact after docs build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Build site
         run: cd docs && mkdocs build -d ../site
 
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
 
   publish:
     needs: build


### PR DESCRIPTION
- upload GitHub Pages artifact after docs build for deploy-pages action