### PR TITLE
Align labeler.yml with actions/labeler syntax

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,11 +2,6 @@
 # See: https://github.com/actions/labeler
 # This configuration uses a prefix system (e.g., 'type:', 'scope:') for clarity and automation.
 
-# --- High-Priority Labels ---
-'BREAKING CHANGE':
-  - title: '(?i)BREAKING CHANGE' # If title contains "BREAKING CHANGE" (case-insensitive)
-  - body: '(?i)BREAKING CHANGE'  # OR if body contains "BREAKING CHANGE" (case-insensitive)
-
 # --- Type Labels ---
 'type: bug':
   - any: ['**/bug_report.md', '**/bug*']
@@ -36,7 +31,5 @@
   - any: ['**/quick-issue.md', '**/agent*']
 'playground':
   - any: ['**/playground*', '**/playground.yml']
-'dependencies':
-  - title: '(?i)^dependabot/' # If title starts with "dependabot/" (case-insensitive)
 'release':
-  - head-branch: '(?i)^release/' # If head branch starts with "release/" (case-insensitive)
+  - head-branch: ['^release'] # If head branch starts with "release"


### PR DESCRIPTION
- Remove unsupported BREAKING CHANGE (title/body) and dependencies (title) labels.
- Correct head-branch regex syntax for 'release' label.
- actions/labeler does not support title/body matching or regex flags like (?i).